### PR TITLE
replaced version test with test for defined symbols

### DIFF
--- a/src/LegacyStrings.jl
+++ b/src/LegacyStrings.jl
@@ -42,7 +42,7 @@ import Base:
     uppercase,
     write
 
-    if VERSION >= v"0.5.0-"
+    if !isdefined(Base, :ASCIIString)
         immutable ASCIIString <: DirectIndexString
             data::Array{UInt8,1}
         end


### PR DESCRIPTION
Checks if `Base.ASCIIString` is defined before redefining legacy string types. This helps keep early 0.5-dev versions functional (cf. #6).

I did not attempt to do the pedantic thing and test for each of the legacy types separately, because `support.jl` contains references to all of them anyways. Thus this PR will not help with Julia versions that fall in the middle of the great Stringapalooza refactoring: https://github.com/JuliaLang/julia/issues/16107
