### PR TITLE
Fix errors on julia 0.7, drop 0.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ os:
   - linux
   - osx
 julia:
-  - 0.5
   - 0.6
+  - 0.7
   - nightly
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 
 [![Julia 0.5 Status](http://pkg.julialang.org/badges/LegacyStrings_0.5.svg)](http://pkg.julialang.org/?pkg=LegacyStrings&ver=0.5)
 [![Julia 0.6 Status](http://pkg.julialang.org/badges/LegacyStrings_0.6.svg)](http://pkg.julialang.org/?pkg=LegacyStrings&ver=0.6)
+[![Julia 0.7 Status](http://pkg.julialang.org/badges/LegacyStrings_0.7.svg)](http://pkg.julialang.org/?pkg=LegacyStrings&ver=0.7)
 
 The LegacyStrings package provides compatibility string types from Julia 0.5 (and earlier), which were removed in subsequent versions, including:
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.5
-Compat 0.18.0
+julia 0.6
+Compat 0.67

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,9 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.7/julia-0.7-latest-win32.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.7/julia-0.7-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/src/LegacyStrings.jl
+++ b/src/LegacyStrings.jl
@@ -23,7 +23,6 @@ export
 import Base:
     containsnul,
     convert,
-    endof,
     getindex,
     isvalid,
     lcfirst,
@@ -31,7 +30,9 @@ import Base:
     lowercase,
     map,
     next,
+    nextind,
     pointer,
+    prevind,
     reverse,
     reverseind,
     rsearch,
@@ -45,70 +46,82 @@ import Base:
     write
 
 using Compat
+using Compat: IOBuffer
+import Compat:
+    lastindex,
+    codeunit,
+    ncodeunits
 
-    if isdefined(Base, :lastidx)
-        import Base: lastidx
-    end
+if isdefined(Base, :iterate)
+    import Base: iterate
+end
 
-    if isdefined(Base, :DirectIndexString)
-        using Base: DirectIndexString
-    else
-        include("directindex.jl")
-    end
+if isdefined(Base, :UnicodeError)
+    import Base: UnicodeError
+else
+    include("unicodeerror.jl")
+end
 
-    if VERSION >= v"0.5.0-"
-        immutable ASCIIString <: DirectIndexString
-            data::Vector{UInt8}
-            ASCIIString(data::String) = new(Vector{UInt8}(data))
-            ASCIIString(data) = new(data)
+if isdefined(Base, :DirectIndexString)
+    using Base: DirectIndexString
+else
+    include("directindex.jl")
+end
+
+struct ASCIIString <: DirectIndexString
+    data::Vector{UInt8}
+    ASCIIString(data::String) = new(Vector{UInt8}(codeunits(data)))
+    ASCIIString(data) = new(data)
+end
+
+struct UTF8String <: AbstractString
+    data::Vector{UInt8}
+    UTF8String(data::String) = new(Vector{UInt8}(codeunits(data)))
+    UTF8String(data) = new(data)
+end
+
+struct UTF16String <: AbstractString
+    data::Vector{UInt16} # includes 16-bit NULL termination after string chars
+    function UTF16String(data::Vector{UInt16})
+        if length(data) < 1 || data[end] != 0
+            throw(UnicodeError(UTF_ERR_NULL_16_TERMINATE, 0, 0))
         end
-
-        immutable UTF8String <: AbstractString
-            data::Vector{UInt8}
-            UTF8String(data::String) = new(Vector{UInt8}(data))
-            UTF8String(data) = new(data)
-        end
-
-        immutable UTF16String <: AbstractString
-            data::Vector{UInt16} # includes 16-bit NULL termination after string chars
-            function UTF16String(data::Vector{UInt16})
-                if length(data) < 1 || data[end] != 0
-                    throw(UnicodeError(UTF_ERR_NULL_16_TERMINATE, 0, 0))
-                end
-                new(data)
-            end
-        end
-
-        immutable UTF32String <: DirectIndexString
-            data::Vector{UInt32} # includes 32-bit NULL termination after string chars
-            function UTF32String(data::Vector{UInt32})
-                if length(data) < 1 || data[end] != 0
-                    throw(UnicodeError(UTF_ERR_NULL_32_TERMINATE, 0, 0))
-                end
-                new(data)
-            end
-        end
-
-        const ByteString = Union{ASCIIString,UTF8String}
-
-        include("support.jl")
-        include("ascii.jl")
-        include("utf8.jl")
-        include("utf16.jl")
-        include("utf32.jl")
-    else
-        using Base: UTF_ERR_SHORT, checkstring
+        new(data)
     end
+end
 
-    if isdefined(Base, :RepString)
-        using Base: RepString
-    else
-        include("rep.jl")
+struct UTF32String <: DirectIndexString
+    data::Vector{UInt32} # includes 32-bit NULL termination after string chars
+    function UTF32String(data::Vector{UInt32})
+        if length(data) < 1 || data[end] != 0
+            throw(UnicodeError(UTF_ERR_NULL_32_TERMINATE, 0, 0))
+        end
+        new(data)
     end
+end
 
-    if isdefined(Base, :RevString)
-        using Base: RevString
-    else
-        include("rev.jl")
-    end
+const ByteString = Union{ASCIIString,UTF8String}
+
+include("support.jl")
+include("ascii.jl")
+include("utf8.jl")
+include("utf16.jl")
+include("utf32.jl")
+include("rep.jl")
+
+if isdefined(Base, :RevString)
+    using Base: RevString
+else
+    include("rev.jl")
+end
+
+const AllLegacyStringTypes = Union{ASCIIString,UTF8String,UTF16String,UTF32String,RepString,RevString}
+
+codeunit(s::SubString{<:AllLegacyStringTypes}) = codeunit(s.string)
+ncodeunits(s::SubString{<:AllLegacyStringTypes}) = isdefined(s, :ncodeunits) ? s.ncodeunits : s.endof
+
+if !isdefined(Base, :iterate)
+    iterate(s::Union{String,SubString,AllLegacyStringTypes}, i::Int) = next(s, i)
+end
+
 end # module

--- a/src/directindex.jl
+++ b/src/directindex.jl
@@ -6,10 +6,12 @@ next(s::DirectIndexString, i::Int) = (s[i],i+1)
 
 length(s::DirectIndexString) = endof(s)
 
-isvalid(s::DirectIndexString, i::Integer) = (start(s) <= i <= endof(s))
+isvalid(s::DirectIndexString, i::Integer) = (firstindex(s) <= i <= lastindex(s))
 
-prevind(s::DirectIndexString, i::Integer) = Int(i)-1
-nextind(s::DirectIndexString, i::Integer) = Int(i)+1
+prevind(s::DirectIndexString, i::Int) = i-1
+nextind(s::DirectIndexString, i::Int) = i+1
+prevind(s::DirectIndexString, i::Integer) = prevind(s, i)
+nextind(s::DirectIndexString, i::Integer) = nextind(s, i)
 
 function prevind(s::DirectIndexString, i::Integer, nchar::Integer)
     nchar > 0 || throw(ArgumentError("nchar must be greater than 0"))
@@ -24,9 +26,9 @@ end
 ind2chr(s::DirectIndexString, i::Integer) = begin checkbounds(s,i); i end
 chr2ind(s::DirectIndexString, i::Integer) = begin checkbounds(s,i); i end
 
-length(s::SubString{<:DirectIndexString}) = endof(s)
+length(s::SubString{<:DirectIndexString}) = lastindex(s)
 
-isvalid(s::SubString{<:DirectIndexString}, i::Integer) = (start(s) <= i <= endof(s))
+isvalid(s::SubString{<:DirectIndexString}, i::Integer) = (firstindex(s) <= i <= ncodeunits(s))
 
 ind2chr(s::SubString{<:DirectIndexString}, i::Integer) = begin checkbounds(s,i); i end
 chr2ind(s::SubString{<:DirectIndexString}, i::Integer) = begin checkbounds(s,i); i end

--- a/src/rep.jl
+++ b/src/rep.jl
@@ -1,23 +1,32 @@
 # This file includes code that was formerly a part of Julia. License is MIT: http://julialang.org/license
 
-immutable RepString <: AbstractString
+struct RepString <: AbstractString
     string::AbstractString
     repeat::Integer
 end
 
-function endof(s::RepString)
-    e = endof(s.string)
-    (next(s.string,e)[2]-1) * (s.repeat-1) + e
+function lastindex(s::RepString)
+    e = lastindex(s.string)
+    (iterate(s.string,e)[2]-1) * (s.repeat-1) + e
 end
 length(s::RepString) = length(s.string)*s.repeat
 sizeof(s::RepString) = sizeof(s.string)*s.repeat
+
+function isvalid(s::RepString, i::Int)
+    1 ≤ i ≤ ncodeunits(s) || return false
+    j = 1
+    while j < i
+        _, j = iterate(s, j)
+    end
+    return j == i
+end
 
 function next(s::RepString, i::Int)
     if i < 1
         throw(BoundsError(s, i))
     end
-    e = endof(s.string)
-    sz = next(s.string,e)[2]-1
+    e = lastindex(s.string)
+    sz = iterate(s.string,e)[2]-1
 
     r, j = divrem(i-1, sz)
     j += 1
@@ -26,8 +35,18 @@ function next(s::RepString, i::Int)
         throw(BoundsError(s, i))
     end
 
-    c, k = next(s.string, j)
+    c, k = iterate(s.string, j)
     c, k-j+i
+end
+
+codeunit(s::RepString) = codeunit(s.string)
+ncodeunits(s::RepString) = ncodeunits(s.string) * s.repeat
+
+if isdefined(Base, :iterate)
+    function iterate(s::RepString, i::Int = firstindex(s))
+        i > ncodeunits(s) && return nothing
+        return next(s, i)
+    end
 end
 
 convert(::Type{RepString}, s::AbstractString) = RepString(s,1)

--- a/src/rev.jl
+++ b/src/rev.jl
@@ -2,18 +2,37 @@
 
 ## reversed strings without data movement ##
 
-immutable RevString{T<:AbstractString} <: AbstractString
+struct RevString{T<:AbstractString} <: AbstractString
     string::T
 end
 
-endof(s::RevString) = endof(s.string)
+lastindex(s::RevString) = lastindex(s.string)
 length(s::RevString) = length(s.string)
 sizeof(s::RevString) = sizeof(s.string)
 
 function next(s::RevString, i::Int)
-    n = endof(s); j = n-i+1
+    n = lastindex(s); j = n-i+1
     (s.string[j], n-prevind(s.string,j)+1)
 end
 
+codeunit(s::RevString) = codeunit(s.string)
+ncodeunits(s::RevString) = ncodeunits(s.string)
+
+if isdefined(Base, :iterate)
+    function iterate(s::RevString, i::Int = firstindex(s))
+        i > lastindex(s) && return nothing
+        return next(s, i)
+    end
+end
+
+function isvalid(s::RevString, i::Int)
+    1 ≤ i ≤ ncodeunits(s) || return false
+    j = 1
+    while j < i
+        _, j = iterate(s, j)
+    end
+    return j == i
+end
+
 reverse(s::RevString) = s.string
-reverseind(s::RevString, i::Integer) = endof(s) - i + 1
+reverseind(s::RevString, i::Integer) = lastindex(s) - i + 1

--- a/src/unicodeerror.jl
+++ b/src/unicodeerror.jl
@@ -1,0 +1,11 @@
+##    Error messages for Unicode / UTF support
+
+struct UnicodeError <: Exception
+    errmsg::AbstractString   ##< A UTF_ERR_ message
+    errpos::Int32            ##< Position of invalid character
+    errchr::UInt32           ##< Invalid character
+end
+
+show(io::IO, exc::UnicodeError) = print(io, replace(replace(string("UnicodeError: ",exc.errmsg),
+    "<<1>>" => string(exc.errpos)),
+    "<<2>>" => string(exc.errchr, base=16)))


### PR DESCRIPTION
All tests pass (locally) without deprecation warnings on both julia 0.6 and 0.7 (some warnings still remain, e.g. the one about exporting `ascii`).

This supersedes #21. I've seen that in that PR there was some debate on whether to abandon the package, but it is required in particular by JLD, so I've put in the work to fix it. Hopefully, no more major fixes will be required after 1.0.