### PR TITLE
Fix a last-minute julia 0.7 deprecation warning

### DIFF
--- a/src/utf8.jl
+++ b/src/utf8.jl
@@ -253,7 +253,7 @@ function convert(::Type{UTF8String}, dat::Vector{UInt8})
             else
                 # Pick up surrogate pairs (CESU-8 format)
                 ch = ((((((ch & 0x3f) << 6) | (dat[pos + 1] & 0x3f)) << 10)
-                       + (((dat[pos + 3] & 0x3f)%UInt32 << 6) | (dat[pos + 4] & 0x3f)))
+                       + ((((dat[pos + 3] & 0x3f)%UInt32) << 6) | (dat[pos + 4] & 0x3f)))
                       - 0x01f0c00)
                 pos += 4
                 output_utf8_4byte!(buf, out, ch)


### PR DESCRIPTION
Add parentheses around a % operation.
After this is merged it would be a good idea to tag a new release I guess.