### PR TITLE
Fix import from Base warnings on Julia 1.0

### DIFF
--- a/src/LegacyStrings.jl
+++ b/src/LegacyStrings.jl
@@ -25,22 +25,17 @@ import Base:
     convert,
     getindex,
     isvalid,
-    lcfirst,
     length,
     lowercase,
     map,
-    next,
     nextind,
     pointer,
     prevind,
     reverse,
     reverseind,
-    rsearch,
-    search,
     show,
     sizeof,
     string,
-    ucfirst,
     unsafe_convert,
     uppercase,
     write
@@ -51,6 +46,26 @@ import Compat:
     lastindex,
     codeunit,
     ncodeunits
+
+if isdefined(Base, :lcfirst)
+    import Base: lcfirst
+end
+
+if isdefined(Base, :next)
+    import Base: next
+end
+
+if isdefined(Base, :rsearch)
+    import Base: rsearch
+end
+
+if isdefined(Base, :search)
+    import Base: search
+end
+
+if isdefined(Base, :ucfirst)
+    import Base: ucfirst
+end
 
 if isdefined(Base, :iterate)
     import Base: iterate

--- a/src/LegacyStrings.jl
+++ b/src/LegacyStrings.jl
@@ -47,41 +47,21 @@ import Compat:
     codeunit,
     ncodeunits
 
-if isdefined(Base, :lcfirst)
+
+if VERSION <= v"0.7-"
     import Base: lcfirst
-end
-
-if isdefined(Base, :next)
     import Base: next
-end
-
-if isdefined(Base, :rsearch)
     import Base: rsearch
-end
-
-if isdefined(Base, :search)
     import Base: search
-end
-
-if isdefined(Base, :ucfirst)
     import Base: ucfirst
-end
-
-if isdefined(Base, :iterate)
-    import Base: iterate
-end
-
-if isdefined(Base, :UnicodeError)
     import Base: UnicodeError
-else
-    include("unicodeerror.jl")
-end
-
-if isdefined(Base, :DirectIndexString)
     using Base: DirectIndexString
 else
+    import Base: iterate
+    include("unicodeerror.jl")
     include("directindex.jl")
 end
+
 
 struct ASCIIString <: DirectIndexString
     data::Vector{UInt8}

--- a/src/LegacyStrings.jl
+++ b/src/LegacyStrings.jl
@@ -48,7 +48,7 @@ import Compat:
     ncodeunits
 
 
-if VERSION <= v"0.7-"
+if VERSION < v"0.7-"
     import Base: lcfirst
     import Base: next
     import Base: rsearch

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -207,7 +207,11 @@ let ch = 0x10000
 end
 
 let str = UTF8String(b"this is a test\xed\x80")
-    @test iterate(str, 15) == ('\ufffd', 16)
+    @static if VERSION < v"0.7-"
+        @test next(str, 15) == ('\ufffd', 16)
+    else
+        @test iterate(str, 15) == ('\ufffd', 16)
+    end
     @test_throws BoundsError getindex(str, 0:3)
     @test_throws BoundsError getindex(str, 17:18)
     @test_throws BoundsError getindex(str, 2:17)
@@ -544,8 +548,13 @@ let
 
     @test lastindex(srep) == 7
 
-    @test iterate(srep, 3) == ('β',5)
-    @test iterate(srep, 7) == ('β',9)
+    @static if VERSION < v"0.7-"
+        @test next(srep, 3) == ('β',5)
+        @test next(srep, 7) == ('β',9)
+    else
+        @test iterate(srep, 3) == ('β',5)
+        @test iterate(srep, 7) == ('β',9)
+    end
 
     @test srep[7] == 'β'
     @static if VERSION < v"0.7.0-DEV.2924"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,7 +6,6 @@ using Compat: view, String
 using LegacyStrings
 using LegacyStrings: ASCIIString, UTF8String # override Compat's version
 import LegacyStrings:
-    ascii,
     checkstring,
     UnicodeError,
     UTF_ERR_SHORT
@@ -208,13 +207,13 @@ let ch = 0x10000
 end
 
 let str = UTF8String(b"this is a test\xed\x80")
-    @test next(str, 15) == ('\ufffd', 16)
+    @test iterate(str, 15) == ('\ufffd', 16)
     @test_throws BoundsError getindex(str, 0:3)
     @test_throws BoundsError getindex(str, 17:18)
     @test_throws BoundsError getindex(str, 2:17)
     @test_throws UnicodeError getindex(str, 16:17)
     # @test string(Char(0x110000)) == "\ufffd"
-    sa = SubString{ASCIIString}(ascii("This is a silly test"), 1, 14)
+    sa = SubString{ASCIIString}(LegacyStrings.ascii("This is a silly test"), 1, 14)
     s8 = convert(SubString{UTF8String}, sa)
     @test typeof(s8) == SubString{UTF8String}
     @test s8 == "This is a sill"
@@ -283,7 +282,7 @@ function tstcvt(strUTF8::UTF8String, strUTF16::UTF16String, strUTF32::UTF32Strin
 end
 
 # Create some ASCII, UTF8, UTF16, and UTF32 strings
-strAscii = ascii("abcdefgh")
+strAscii = LegacyStrings.ascii("abcdefgh")
 strA_UTF8 = utf8(("abcdefgh\uff")[1:8])
 strL_UTF8 = utf8("abcdef\uff\uff")
 str2_UTF8 = utf8("abcd\uff\uff\u7ff\u7ff")
@@ -464,7 +463,7 @@ end
 @test reverse(utf32("abcd \uff\u7ff\u7fff\U7ffff")) == utf32("\U7ffff\u7fff\u7ff\uff dcba")
 
 # Test pointer() functions
-let str = ascii("this ")
+let str = LegacyStrings.ascii("this ")
     u8  = utf8(str)
     u16 = utf16(str)
     u32 = utf32(str)
@@ -545,8 +544,8 @@ let
 
     @test lastindex(srep) == 7
 
-    @test next(srep, 3) == ('β',5)
-    @test next(srep, 7) == ('β',9)
+    @test iterate(srep, 3) == ('β',5)
+    @test iterate(srep, 7) == ('β',9)
 
     @test srep[7] == 'β'
     @static if VERSION < v"0.7.0-DEV.2924"


### PR DESCRIPTION
This PR fixes the import warnings described in #35. It is a continuation of PR #33 by @quinnj.

I took the comments in #33 and fixed the tests as well. Locally they all pass on 0.6 and 1.0. Let's see how CI does.