### PR TITLE
add isascii methods for ASCIIString, RepString and RevString

### DIFF
--- a/src/LegacyStrings.jl
+++ b/src/LegacyStrings.jl
@@ -24,6 +24,7 @@ import Base:
     containsnul,
     convert,
     getindex,
+    isascii,
     isvalid,
     length,
     lowercase,

--- a/src/ascii.jl
+++ b/src/ascii.jl
@@ -100,6 +100,8 @@ end
 
 reverse(s::ASCIIString) = ASCIIString(reverse(s.data))
 
+isascii(::ASCIIString) = true
+
 ## outputing ASCII strings ##
 
 write(io::IO, s::ASCIIString) = write(io, s.data)

--- a/src/rep.jl
+++ b/src/rep.jl
@@ -51,4 +51,4 @@ end
 
 convert(::Type{RepString}, s::AbstractString) = RepString(s,1)
 
-isascii(s::RepString) = isascii(s.string)
+isascii(s::RepString) = iszero(s.repeat) || isascii(s.string)

--- a/src/rep.jl
+++ b/src/rep.jl
@@ -50,3 +50,5 @@ if isdefined(Base, :iterate)
 end
 
 convert(::Type{RepString}, s::AbstractString) = RepString(s,1)
+
+isascii(s::RepString) = isascii(s.string)

--- a/src/rev.jl
+++ b/src/rev.jl
@@ -36,3 +36,5 @@ end
 
 reverse(s::RevString) = s.string
 reverseind(s::RevString, i::Integer) = lastindex(s) - i + 1
+
+isascii(s::RevString) = isascii(s.string)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -591,3 +591,12 @@ let
         end
     end
 end
+
+
+## isascii ##
+
+for s in ["", "a", "â", "abcde", "abçde"]
+    isascii(s) && @test isascii(LegacyStrings.ascii(s))
+    @test isascii(s) == isascii(RepString(s, 3))
+    @test isascii(s) == isascii(RevString(s))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -598,5 +598,6 @@ end
 for s in ["", "a", "â", "abcde", "abçde"]
     isascii(s) && @test isascii(LegacyStrings.ascii(s))
     @test isascii(s) == isascii(RepString(s, 3))
+    @test isascii(RepString(s, 0))
     @test isascii(s) == isascii(RevString(s))
 end


### PR DESCRIPTION
The new methods are faster than the default one. (For `RevString`, this is true at least once JuliaLang/julia#48568 is merged.)