### PR TITLE
fix `codeunit` and `ncodeunits`

### DIFF
--- a/src/LegacyStrings.jl
+++ b/src/LegacyStrings.jl
@@ -20,6 +20,8 @@ export
     utf32,
     wstring
 
+using Base: @propagate_inbounds
+
 import Base:
     containsnul,
     convert,
@@ -112,6 +114,11 @@ else
 end
 
 const AllLegacyStringTypes = Union{ASCIIString,UTF8String,UTF16String,UTF32String,RepString,RevString}
+
+@propagate_inbounds function codeunit(s::Union{ASCIIString,UTF8String,UTF16String,UTF32String}, i::Integer)
+    @boundscheck checkbounds(codeunits(s), i)
+    @inbounds s.data[i]
+end
 
 codeunit(s::SubString{<:AllLegacyStringTypes}) = codeunit(s.string)
 ncodeunits(s::SubString{<:AllLegacyStringTypes}) = isdefined(s, :ncodeunits) ? s.ncodeunits : s.endof

--- a/src/rep.jl
+++ b/src/rep.jl
@@ -40,6 +40,11 @@ function next(s::RepString, i::Int)
 end
 
 codeunit(s::RepString) = codeunit(s.string)
+@propagate_inbounds function codeunit(s::RepString, i::Integer)
+    @boundscheck checkbounds(codeunits(s), i)
+    @inbounds codeunit(s.string, (i-1) % ncodeunits(s.string) + 1)
+end
+
 ncodeunits(s::RepString) = ncodeunits(s.string) * s.repeat
 
 if isdefined(Base, :iterate)

--- a/src/rev.jl
+++ b/src/rev.jl
@@ -16,6 +16,15 @@ function next(s::RevString, i::Int)
 end
 
 codeunit(s::RevString) = codeunit(s.string)
+@propagate_inbounds function codeunit(s::RevString, i::Integer)
+    @boundscheck checkbounds(codeunits(s), i)
+    s = s.string
+    j = ncodeunits(s)-i+1
+    j0 = thisind(s, j)
+    j1 = nextind(s, j0)
+    @inbounds codeunit(s, j0+j1-j-1)
+end
+
 ncodeunits(s::RevString) = ncodeunits(s.string)
 
 if isdefined(Base, :iterate)

--- a/src/utf32.jl
+++ b/src/utf32.jl
@@ -8,7 +8,7 @@ lastindex(s::UTF32String) = length(s.data) - 1
 length(s::UTF32String) = length(s.data) - 1
 
 codeunit(s::UTF32String) = UInt32
-ncodeunits(s::UTF32String) = length(s.data)
+ncodeunits(s::UTF32String) = length(s.data) - 1
 
 if isdefined(Base, :iterate)
     function iterate(s::UTF32String, i::Int = firstindex(s))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -608,6 +608,7 @@ end
 function test_codeunit(s0, s, to_str)
     cu = codeunits(s)
     @test length(cu) == ncodeunits(s)
+    isempty(s) || @test codeunit(s, 1) isa codeunit(s)
     @test_throws BoundsError cu[0]
     @test_throws BoundsError cu[end+1]
     @test s0 == to_str(collect(cu))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -601,3 +601,38 @@ for s in ["", "a", "â", "abcde", "abçde"]
     @test isascii(RepString(s, 0))
     @test isascii(s) == isascii(RevString(s))
 end
+
+
+## codeunit, codeunits and ncodeunits ##
+
+function test_codeunit(s0, s, to_str)
+    cu = codeunits(s)
+    @test length(cu) == ncodeunits(s)
+    @test_throws BoundsError cu[0]
+    @test_throws BoundsError cu[end+1]
+    @test s0 == to_str(collect(cu))
+end
+
+for s0 in ["", "Julia = Juliet", "Julia = Ιουλιέτα = 朱丽叶 ≠ 𐍈"]
+    for u in [identity, LegacyStrings.ascii, utf8, utf16, utf32]
+        u == LegacyStrings.ascii && !isascii(s0) && continue
+
+        s1 = u(s0)
+
+        # function to convert codeunits to the type of s1
+        to_str = u === identity ? String : (cu -> convert(typeof(s1), cu))
+
+        # ASCIIString, UTF8String, UTF16String, UTF32String
+        test_codeunit(s0, s1, to_str)
+
+        # RepString
+        for k in [0, 1, 3]
+            s2 = RepString(s1, k)
+            test_codeunit(s0^k, s2, to_str)
+        end
+
+        # RevString
+        s2 = RevString(s1)
+        test_codeunit(reverse(s0), s2, to_str)
+    end
+end


### PR DESCRIPTION
`codeunit(s, i::Integer)` was not implemented for any string type provided by this package. This is necessary for accessing or displaying `codeunits(s)`.

Also, `ncodeunits(s::UTF32String)` was not taking into account the trailing 32-bit NULL.

These changes also are needed for compatibility with JuliaLang/julia#48568.