### PR TITLE
change `RepString` fields to concrete types

### DIFF
--- a/src/rep.jl
+++ b/src/rep.jl
@@ -1,8 +1,8 @@
 # This file includes code that was formerly a part of Julia. License is MIT: http://julialang.org/license
 
-struct RepString <: AbstractString
-    string::AbstractString
-    repeat::Integer
+struct RepString{T<:AbstractString} <: AbstractString
+    string::T
+    repeat::Int
 end
 
 function lastindex(s::RepString)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -537,7 +537,7 @@ let
     @test sizeof(rs) == 6
     @test isascii(rs)
     @test convert(RepString, "foobar") == "foobar"
-    @test typeof(convert(RepString, "foobar")) == RepString
+    @test convert(RepString, "foobar") isa RepString
 
     srep = RepString("Σβ",2)
     s="Σβ"


### PR DESCRIPTION
This has the obvious performance benefits. All tests still pass (with one small modification).