### PR TITLE
allow construction of `ASCIIString` and `UTF8String` via `AbstractVector{UInt8}`

### DIFF
--- a/src/ascii.jl
+++ b/src/ascii.jl
@@ -117,9 +117,7 @@ convert(::Type{ASCIIString}, a::Vector{UInt8}) = begin
     isvalid(ASCIIString,a) || throw(ArgumentError("invalid ASCII sequence"))
     return ASCIIString(a)
 end
-if isdefined(Base, :codeunits)
-    convert(::Type{ASCIIString}, a::Base.CodeUnits{UInt8,String}) = convert(ASCIIString, Vector{UInt8}(a))
-end
+convert(::Type{ASCIIString}, a::AbstractVector{UInt8}) = convert(ASCIIString, Vector{UInt8}(a))
 
 ascii(p::Ptr{UInt8}) =
     ascii(p, p == C_NULL ? Csize_t(0) : ccall(:strlen, Csize_t, (Ptr{UInt8},), p))

--- a/src/utf8.jl
+++ b/src/utf8.jl
@@ -211,7 +211,7 @@ convert(::Type{UTF8String}, s::ASCIIString) = UTF8String(s.data)
 convert(::Type{SubString{UTF8String}}, s::SubString{ASCIIString}) =
     SubString(utf8(s.string), s.offset+1, ncodeunits(s)+s.offset)
 
-function convert(::Type{UTF8String}, dat::Vector{UInt8})
+function convert(::Type{UTF8String}, dat::AbstractVector{UInt8})
     # handle zero length string quickly
     isempty(dat) && return empty_utf8
     # get number of bytes to allocate
@@ -286,10 +286,6 @@ function convert(::Type{UTF8String}, a::Vector{UInt8}, invalids_as::AbstractStri
     UTF8String(a)
 end
 convert(::Type{UTF8String}, s::AbstractString) = utf8(bytestring(s))
-
-if isdefined(Base, :CodeUnits)
-    convert(::Type{UTF8String}, s::Base.CodeUnits{UInt8,String}) = convert(UTF8String, Vector{UInt8}(s))
-end
 
 """
 Converts an already validated vector of `UInt16` or `UInt32` to a `UTF8String`

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -647,3 +647,16 @@ for s0 in ["", "Julia = Juliet", "Julia = Ιουλιέτα = 朱丽叶 ≠ 𐍈"
         test_codeunit(reverse(s0), s2, to_str)
     end
 end
+
+
+# construction of strings via AbstractVector
+
+for s0 in ["", "Julia = Juliet", "Julia = Ιουλιέτα = 朱丽叶 ≠ 𐍈"]
+    for u in [LegacyStrings.ascii, utf8, utf16, utf32]
+        u == LegacyStrings.ascii && !isascii(s0) && continue
+        s = u(s0)
+        cu = codeunits(s)
+        @test s == u(cu)
+        @test s == u(view(cu, 1:length(cu)))
+    end
+end


### PR DESCRIPTION
Then separate methods for a `CodeUnits` argument are not necessary anymore. Note that for `UTF16String` and `UTF32String` the analogous constructions are already possible.