### PR TITLE
nextind/prevind fixes

### DIFF
--- a/src/directindex.jl
+++ b/src/directindex.jl
@@ -10,18 +10,21 @@ isvalid(s::DirectIndexString, i::Integer) = (firstindex(s) <= i <= lastindex(s))
 
 prevind(s::DirectIndexString, i::Int) = i-1
 nextind(s::DirectIndexString, i::Int) = i+1
-prevind(s::DirectIndexString, i::Integer) = prevind(s, i)
-nextind(s::DirectIndexString, i::Integer) = nextind(s, i)
+prevind(s::DirectIndexString, i::Integer) = prevind(s, Int(i))
+nextind(s::DirectIndexString, i::Integer) = nextind(s, Int(i))
 
-function prevind(s::DirectIndexString, i::Integer, nchar::Integer)
-    nchar > 0 || throw(ArgumentError("nchar must be greater than 0"))
-    Int(i)-nchar
+function prevind(s::DirectIndexString, i::Int, nchar::Int)
+    nchar ≥ 0 || throw(ArgumentError("n cannot be negative: $nchar"))
+    return i-nchar
 end
 
-function nextind(s::DirectIndexString, i::Integer, nchar::Integer)
-    nchar > 0 || throw(ArgumentError("nchar must be greater than 0"))
-    Int(i)+nchar
+function nextind(s::DirectIndexString, i::Int, nchar::Int)
+    nchar ≥ 0 || throw(ArgumentError("n cannot be negative: $nchar"))
+    return i+nchar
 end
+
+prevind(s::DirectIndexString, i::Integer, n::Integer) = prevind(s, Int(i), Int(n))
+nextind(s::DirectIndexString, i::Integer, n::Integer) = nextind(s, Int(i), Int(n))
 
 ind2chr(s::DirectIndexString, i::Integer) = begin checkbounds(s,i); i end
 chr2ind(s::DirectIndexString, i::Integer) = begin checkbounds(s,i); i end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -660,3 +660,16 @@ for s0 in ["", "Julia = Juliet", "Julia = Ιουλιέτα = 朱丽叶 ≠ 𐍈"
         @test s == u(view(cu, 1:length(cu)))
     end
 end
+
+# nextind/prevind, issue #52
+@testset "nextind/prevind" begin
+    s = ASCIIString("foobar")
+    @test nextind(s, 1) == nextind(s, Int8(1)) === 2
+    @test prevind(s, 2) == prevind(s, Int8(2)) === 1
+    @test nextind(s, 1, 0) == nextind(s, Int8(1), Int8(0)) === 1
+    @test prevind(s, 2, 0) == prevind(s, Int8(2), Int8(0)) === 2
+    @test nextind(s, 1, 3) === 4
+    @test prevind(s, 4, 3) === 1
+    @test_throws ArgumentError nextind(s, 1, -1)
+    @test_throws ArgumentError prevind(s, 2, -1)
+end


### PR DESCRIPTION
Fixes #52 and some other bugs (e.g. there was an infinite dispatch loop for the `Integer` case, and it incorrectly rejected `nchar == 0` unlike `Base`).