### PR TITLE
drop julia < 1.0 support, update to github CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,72 @@
+name: CI
+# Run on master, tags, or any pull request
+on:
+  schedule:
+    - cron: '0 2 * * *'  # Daily at 2 AM UTC (8 PM CST)
+  push:
+    branches: [master]
+    tags: ["*"]
+  pull_request:
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: only if it is a pull request build.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - "1.0"  # LTS
+          - "1"    # Latest Release
+        os:
+          - ubuntu-latest
+          - macOS-latest
+          - windows-latest
+        arch:
+          - x64
+          - x86
+        exclude:
+          # Test 32-bit only on Linux
+          - os: macOS-latest
+            arch: x86
+          - os: windows-latest
+            arch: x86
+        include:
+          # Add specific version used to run the reference tests.
+          # Must be kept in sync with version check in `test/runtests.jl`,
+          # and with the branch protection rules on the repository which
+          # require this specific job to pass on all PRs
+          # (see Settings > Branches > Branch protection rules).
+          - os: ubuntu-latest
+            version: 1.7.2
+            arch: x64
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: actions/cache@v2
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-${{ matrix.arch }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.arch }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-${{ matrix.arch }}-test-
+            ${{ runner.os }}-${{ matrix.arch }}-
+            ${{ runner.os }}-
+      - uses: julia-actions/julia-buildpkg@latest
+      - run: |
+          git config --global user.name Tester
+          git config --global user.email te@st.er
+      - uses: julia-actions/julia-runtest@latest
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v2
+        with:
+          files: lcov.info

--- a/Project.toml
+++ b/Project.toml
@@ -2,11 +2,7 @@ name = "LegacyStrings"
 uuid = "1b4a561d-cfcb-5daf-8433-43fcf8b4bea3"
 version = "1.1"
 
-[deps]
-Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
-
 [compat]
-Compat = "0.67, 0.68, 0.69, 0.70, 1, 2, 3, 4"
 julia = "1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LegacyStrings"
 uuid = "1b4a561d-cfcb-5daf-8433-43fcf8b4bea3"
-version = "1.0"
+version = "1.1"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
@@ -8,3 +8,9 @@ Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 [compat]
 Compat = "0.67, 0.68, 0.69, 0.70, 1, 2, 3, 4"
 julia = "1"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/README.md
+++ b/README.md
@@ -1,11 +1,6 @@
 # LegacyStrings
 
-[![Travis CI Build Status](https://travis-ci.org/JuliaStrings/LegacyStrings.jl.svg?branch=master)](https://travis-ci.org/JuliaStrings/LegacyStrings.jl)
-[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/ib52329urgg62jai?svg=true)](https://ci.appveyor.com/project/nalimilan/legacystrings-jl)
-
-[![Julia 0.5 Status](http://pkg.julialang.org/badges/LegacyStrings_0.5.svg)](http://pkg.julialang.org/?pkg=LegacyStrings&ver=0.5)
-[![Julia 0.6 Status](http://pkg.julialang.org/badges/LegacyStrings_0.6.svg)](http://pkg.julialang.org/?pkg=LegacyStrings&ver=0.6)
-[![Julia 0.7 Status](http://pkg.julialang.org/badges/LegacyStrings_0.7.svg)](http://pkg.julialang.org/?pkg=LegacyStrings&ver=0.7)
+[![CI](https://github.com/JuliaStrings/LegacyStrings.jl/workflows/CI/badge.svg)](https://github.com/JuliaStrings/LegacyStrings.jl/actions?query=workflow%3ACI)
 
 The LegacyStrings package provides compatibility string types from Julia 0.5 (and earlier), which were removed in subsequent versions, including:
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,0 @@
-julia 0.6
-Compat 0.67

--- a/src/LegacyStrings.jl
+++ b/src/LegacyStrings.jl
@@ -21,14 +21,18 @@ export
 using Base: @propagate_inbounds
 
 import Base:
+    codeunit,
     containsnul,
     convert,
     getindex,
     isascii,
     isvalid,
+    iterate,
+    lastindex,
     length,
     lowercase,
     map,
+    ncodeunits,
     nextind,
     pointer,
     prevind,
@@ -41,7 +45,6 @@ import Base:
     uppercase,
     write
 
-import Base: iterate
 include("unicodeerror.jl")
 include("directindex.jl")
 

--- a/src/LegacyStrings.jl
+++ b/src/LegacyStrings.jl
@@ -1,7 +1,5 @@
 # This file includes code that was formerly a part of Julia. License is MIT: http://julialang.org/license
 
-__precompile__(true)
-
 module LegacyStrings
 
 export
@@ -43,28 +41,9 @@ import Base:
     uppercase,
     write
 
-using Compat
-using Compat: IOBuffer
-import Compat:
-    lastindex,
-    codeunit,
-    ncodeunits
-
-
-if VERSION < v"0.7-"
-    import Base: lcfirst
-    import Base: next
-    import Base: rsearch
-    import Base: search
-    import Base: ucfirst
-    import Base: UnicodeError
-    using Base: DirectIndexString
-else
-    import Base: iterate
-    include("unicodeerror.jl")
-    include("directindex.jl")
-end
-
+import Base: iterate
+include("unicodeerror.jl")
+include("directindex.jl")
 
 struct ASCIIString <: DirectIndexString
     data::Vector{UInt8}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,6 @@
 # This file includes code that was formerly a part of Julia. License is MIT: http://julialang.org/license
 
-using Compat
-using Compat.Test
-using Compat: view, String
+using Test
 using LegacyStrings
 using LegacyStrings: ASCIIString, UTF8String # override Compat's version
 import LegacyStrings:
@@ -207,11 +205,8 @@ let ch = 0x10000
 end
 
 let str = UTF8String(b"this is a test\xed\x80")
-    @static if VERSION < v"0.7-"
-        @test next(str, 15) == ('\ufffd', 16)
-    else
-        @test iterate(str, 15) == ('\ufffd', 16)
-    end
+    @test iterate(str, 15) == ('\ufffd', 16)
+
     @test_throws BoundsError getindex(str, 0:3)
     @test_throws BoundsError getindex(str, 17:18)
     @test_throws BoundsError getindex(str, 2:17)
@@ -548,20 +543,11 @@ let
 
     @test lastindex(srep) == 7
 
-    @static if VERSION < v"0.7-"
-        @test next(srep, 3) == ('β',5)
-        @test next(srep, 7) == ('β',9)
-    else
-        @test iterate(srep, 3) == ('β',5)
-        @test iterate(srep, 7) == ('β',9)
-    end
+    @test iterate(srep, 3) == ('β',5)
+    @test iterate(srep, 7) == ('β',9)
 
     @test srep[7] == 'β'
-    @static if VERSION < v"0.7.0-DEV.2924"
-        @test_throws BoundsError srep[8]
-    else
-        @test_throws StringIndexError srep[8]
-    end
+    @test_throws StringIndexError srep[8]
 end
 
 


### PR DESCRIPTION
The Travis stuff has been obsolete for a while.   And it doesn't make sense these days to keep messing around with support for Julia < 1.0.