### PR TITLE
fix obsolete assumptions that Char == UTF-32

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -585,7 +585,12 @@ for s in ["", "a", "â", "Julia", "줄리아"]
     for u in [LegacyStrings.ascii, utf8, utf16, utf32]
         u == LegacyStrings.ascii && !isascii(s) && continue
         @test length(s) == length(u(s))
+        @test map(uppercase, s) == map(uppercase, u(s))
     end
+    c = collect(s)
+    c0 = [c; Char(0)]
+    @test utf32(c) == UTF32String(c) == s
+    GC.@preserve c0 @test utf32(pointer(c0)) == s
 end
 
 


### PR DESCRIPTION
When this code was originally written (< Julia 0.6), `Char` was bit-equivalent to UTF-32, but in Julia 1.x that is no longer the case and a bunch of code was broken.   This PR fixes those issues.

(The code could be further optimized to allocate fewer temporary arrays during conversions, but I doubt it's worth it nowadays.)

Fixes #38.